### PR TITLE
Remove PHP 4 style constructors

### DIFF
--- a/Config.php
+++ b/Config.php
@@ -75,7 +75,7 @@ class Config {
     *
     * @access public
     */
-    function Config()
+    function __construct()
     {
         $this->container = new Config_Container('section', 'root');
     } // end constructor

--- a/Config/Container.php
+++ b/Config/Container.php
@@ -82,7 +82,7 @@ class Config_Container {
     * @param  string  $content    Content of container object
     * @param  array   $attributes Array of attributes for container object
     */
-    function Config_Container($type = 'section', $name = '', $content = '', $attributes = null)
+    function __construct($type = 'section', $name = '', $content = '', $attributes = null)
     {
         $this->type       = $type;
         $this->name       = $name;


### PR DESCRIPTION
This makes Config compatible with PHP 7. It gets rid of the depreciation notices.