### PR TITLE
Handle cases of count(null) in Container.php

### DIFF
--- a/Config.php
+++ b/Config.php
@@ -20,7 +20,7 @@
 require_once('PEAR.php');
 require_once('Config/Container.php');
 
-$GLOBALS['CONFIG_TYPES'] = 
+$GLOBALS['CONFIG_TYPES'] =
         array(
             'apache'        => array('Config/Container/Apache.php', 'Config_Container_Apache'),
             'genericconf'   => array('Config/Container/GenericConf.php', 'Config_Container_GenericConf'),
@@ -75,7 +75,7 @@ class Config {
     *
     * @access public
     */
-    function Config()
+    function __construct()
     {
         $this->container = new Config_Container('section', 'root');
     } // end constructor
@@ -175,7 +175,7 @@ class Config {
     /**
     * Parses the datasource contents
     *
-    * This method will parse the datasource given and fill the root 
+    * This method will parse the datasource given and fill the root
     * Config_Container object with other Config_Container objects.
     *
     * @param mixed   $datasrc     Datasource to parse

--- a/Config/Container.php
+++ b/Config/Container.php
@@ -694,7 +694,7 @@ class Config_Container {
         $array[$this->name] = array();
         switch ($this->type) {
             case 'directive':
-                if ($useAttr && is_countable($this->attributes) && count($this->attributes) > 0) {
+                if ($useAttr && !empty($this->attributes)) {
                     $array[$this->name]['#'] = $this->content;
                     $array[$this->name]['@'] = $this->attributes;
                 } else {
@@ -702,7 +702,7 @@ class Config_Container {
                 }
                 break;
             case 'section':
-                if ($useAttr && is_countable($this->attributes) && count($this->attributes) > 0) {
+                if ($useAttr && !empty($this->attributes)) {
                     $array[$this->name]['@'] = $this->attributes;
                 }
                 if ($count = count($this->children)) {

--- a/Config/Container.php
+++ b/Config/Container.php
@@ -694,7 +694,7 @@ class Config_Container {
         $array[$this->name] = array();
         switch ($this->type) {
             case 'directive':
-                if ($useAttr && count($this->attributes) > 0) {
+                if ($useAttr && is_countable($this->attributes) && count($this->attributes) > 0) {
                     $array[$this->name]['#'] = $this->content;
                     $array[$this->name]['@'] = $this->attributes;
                 } else {
@@ -702,7 +702,7 @@ class Config_Container {
                 }
                 break;
             case 'section':
-                if ($useAttr && count($this->attributes) > 0) {
+                if ($useAttr && is_countable($this->attributes) && count($this->attributes) > 0) {
                     $array[$this->name]['@'] = $this->attributes;
                 }
                 if ($count = count($this->children)) {

--- a/Config/Container.php
+++ b/Config/Container.php
@@ -57,7 +57,7 @@ class Config_Container {
     * @var  object
     */
     var $parent;
-    
+
     /**
     * Array of attributes for this item
     * @var  array
@@ -82,7 +82,7 @@ class Config_Container {
     * @param  string  $content    Content of container object
     * @param  array   $attributes Array of attributes for container object
     */
-    function Config_Container($type = 'section', $name = '', $content = '', $attributes = null)
+    function __construct($type = 'section', $name = '', $content = '', $attributes = null)
     {
         $this->type       = $type;
         $this->name       = $name;
@@ -112,7 +112,7 @@ class Config_Container {
         $result =& $this->addItem($item, $where, $target);
         return $result;
     } // end func &createItem
-    
+
     /**
     * Adds an item to this item.
     * @param  object   $item      a container object
@@ -204,7 +204,7 @@ class Config_Container {
     * Adds a section to this item.
     *
     * This is a helper method that calls createItem
-    * If the section already exists, it won't create a new one. 
+    * If the section already exists, it won't create a new one.
     * It will return reference to existing item.
     *
     * @param  string    $name           Name of new section
@@ -305,7 +305,7 @@ class Config_Container {
 
     /**
     * Finds a node using XPATH like format.
-    * 
+    *
     * The search format is an array:
     * array(item1, item2, item3, ...)
     *
@@ -314,9 +314,9 @@ class Config_Container {
     * item = array('string', array('name' => 'xyz'))
     * will match the container name 'string' whose attribute name is equal to "xyz"
     * For example : <string name="xyz">
-    * 
+    *
     * @param    mixed   Search path and attributes
-    * 
+    *
     * @return   mixed   Config_Container object, array of Config_Container objects or false on failure.
     * @access   public
     */
@@ -350,10 +350,10 @@ class Config_Container {
 
     /**
     * Return a child directive's content.
-    * 
+    *
     * This method can use two different search approach, depending on
     * the parameter it is given. If the parameter is an array, it will use
-    * the {@link Config_Container::searchPath()} method. If it is a string, 
+    * the {@link Config_Container::searchPath()} method. If it is a string,
     * it will use the {@link Config_Container::getItem()} method.
     *
     * Example:
@@ -376,7 +376,7 @@ class Config_Container {
     * @param    mixed   Search path and attributes or a directive name
     * @param    int     Index of the item in the returned directive list.
     *                   Eventually used if args is a string.
-    * 
+    *
     * @return   mixed   Content of directive or false if not found.
     * @access   public
     */
@@ -408,7 +408,7 @@ class Config_Container {
         $count = 0;
         if (isset($name) && isset($type)) {
             for ($i = 0, $children = count($this->children); $i < $children; $i++) {
-                if ($this->children[$i]->name === $name && 
+                if ($this->children[$i]->name === $name &&
                     $this->children[$i]->type == $type) {
                     $count++;
                 }
@@ -548,7 +548,7 @@ class Config_Container {
     {
         $this->content = $content;
     } // end func setContent
-    
+
     /**
     * Get this item's content.
     * @return string    item's content
@@ -608,7 +608,7 @@ class Config_Container {
     {
         return $this->attributes;
     } // end func getAttributes
-    
+
     /**
     * Get one attribute value of this item
     * @param  string   $attribute        Attribute key
@@ -694,7 +694,7 @@ class Config_Container {
         $array[$this->name] = array();
         switch ($this->type) {
             case 'directive':
-                if ($useAttr && count($this->attributes) > 0) {
+                if ($useAttr && is_countable($this->attributes) && count($this->attributes) > 0) {
                     $array[$this->name]['#'] = $this->content;
                     $array[$this->name]['@'] = $this->attributes;
                 } else {
@@ -702,7 +702,7 @@ class Config_Container {
                 }
                 break;
             case 'section':
-                if ($useAttr && count($this->attributes) > 0) {
+                if ($useAttr && is_countable($this->attributes) && count($this->attributes) > 0) {
                     $array[$this->name]['@'] = $this->attributes;
                 }
                 if ($count = count($this->children)) {
@@ -732,10 +732,10 @@ class Config_Container {
         }
         return $array;
     } // end func toArray
-    
+
     /**
     * Writes the configuration to a file
-    * 
+    *
     * @param  mixed  $datasrc        Info on datasource such as path to the configuraton file or dsn...
     * @param  string $configType     Type of configuration
     * @param  array  $options        Options for writer

--- a/README.md
+++ b/README.md
@@ -1,3 +1,0 @@
-# Fork of pear/Config for PHP7.2
-
-This fork handles cases when count() is called on null.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# Fork of pear/Config for PHP7.2
+
+This fork removes PHP4 style constructors and handles cases when count() is called on null.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Fork of pear/Config for PHP7.2
 
-This fork removes PHP4 style constructors and handles cases when count() is called on null.
+This fork handles cases when count() is called on null.

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,11 @@
         "issues": "http://pear.php.net/bugs/search.php?cmd=display&package_name[]=Config",
         "source": "https://github.com/pear/Config"
     },
+    "config": {
+        "platform": {
+            "php": ">=7.2"
+        }
+    },
     "type": "library",
     "require": {
         "pear/pear_exception": "*"

--- a/package.xml
+++ b/package.xml
@@ -122,7 +122,7 @@ BC Break: Drop PHP4 support entirely
  <dependencies>
   <required>
    <php>
-    <min>5.0.0</min>
+    <min>7.2.0</min>
    </php>
    <pearinstaller>
     <min>1.4.0b1</min>


### PR DESCRIPTION
Sometimes count() gets called on null, which is not possible in PHP7.2.